### PR TITLE
Implemented app commands 'delgroup' and 'addgroup' and modified help message for 'viewgroups'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ __pycache__
 *.pyc
 .DS_Store
 .vscode
+*.swp
+tags

--- a/bin/config.py
+++ b/bin/config.py
@@ -115,8 +115,11 @@ class EdgeGridConfig():
         create_parser.add_argument('--var', dest="variables", action='append', nargs='+')
         subsub.add_parser("delete", help="Delete an application")
         subsub.add_parser("view", help="Dump application configuration (JSON)")
-        subsub.add_parser("viewgroups", help="Dump application configuration (JSON)")
+        subsub.add_parser("viewgroups", help="View groups associated to application")
         subsub.add_parser("delgroup", help="Remove group from application, appgroup ID must provided")
+        addgrp_parser = subsub.add_parser("addgroup", help="Add group(s) to application, app ID and appgroup ID must provided")
+        addgrp_parser.add_argument(dest="appgrp_id", nargs="+",
+                                   help='Add group(s) to application')
 
         cert_parser = subparsers.add_parser('certificate', aliases=["cert"], help='Manage EAA Certificates')
         cert_parser.add_argument(dest='certificate_id', nargs="?", default=None,

--- a/libeaa/application.py
+++ b/libeaa/application.py
@@ -132,8 +132,15 @@ class ApplicationAPI(BaseAPI):
             for a in applications:
                 self.loadgroups(a)
         elif config.action == 'delgroup':
-            for ag in applications:
-                self.delgroup(ag)
+            for a in applications:
+                self.delgroup(a)
+        elif config.action == 'addgroup':
+            for a in applications:
+                appgrps = []
+                for ag in set(config.appgrp_id):
+                    appgrp_moniker = EAAItem(ag)
+                    appgrps.append(appgrp_moniker.uuid)
+                self.addgroup(a, appgrps)
         elif config.action in ('attach', 'detach'):
             for a in applications:
                 connectors = []
@@ -229,6 +236,13 @@ class ApplicationAPI(BaseAPI):
                              json={'deleted_objects': [appgroup_moniker.uuid]})
         if deletion.status_code == 200:
             cli.print("Association %s deleted." % appgroup_moniker)
+
+    def addgroup(self, app_moniker, appgrps):
+        cli.print("Add App-group(s) %s to %s ..." % (', '.join(appgrps), app_moniker))
+        addition = self.post('mgmt-pop/appgroups',
+                              json = {"data":[{"apps":[app_moniker.uuid],"groups": [{"uuid_url": "" + gi + "","enable_mfa":"inherit"} for gi in appgrps]}]})
+        if addition.status_code == 200:
+            cli.print("Association %s added." % (', '.join(appgrps)))
 
     def cloudzone_lookup(self, name):
         """Lookup a cloud zone UUID based on it's name."""

--- a/libeaa/application.py
+++ b/libeaa/application.py
@@ -132,7 +132,7 @@ class ApplicationAPI(BaseAPI):
             for a in applications:
                 self.loadgroups(a)
         elif config.action == 'delgroup':
-            for ag in appgroups:
+            for ag in applications:
                 self.delgroup(ag)
         elif config.action in ('attach', 'detach'):
             for a in applications:


### PR DESCRIPTION
## Summary of Changes
-  Implemented `delgroup` as a command in the app. `delgroup` already existed in the code but was not functioning properly, so it was fixed.
-  Added `addgroup` as a command in the app.
-   The help message for `viewgroups` was revised as it was previously overlapping with `view`.

## Background
The addition and deletion of groups to application are currently not publicly available as an EAA API. By allowing these operations to be performed via CLI, I expect to easier change the app settings.

API summary:
https://techdocs.akamai.com/eaa-api/reference/api-summary

## Usage

Delete group associated with a particular application:
`$ akamai-eaa app appgrp://ef99oyiYQSWNI3NR0jnziw delgroup
`
Add group(s) associated with a particular application:
`
$ akamai-eaa app app://I03qOa5lREaTNTARE-MhUA addgroup appgrp://MuAbXYr1Quiorlk1Bg7OJA appgrp://c6geiXLeTDWGL9TdM4WXPg
`